### PR TITLE
Add can fulfill intent

### DIFF
--- a/flask_clova/models.py
+++ b/flask_clova/models.py
@@ -74,6 +74,13 @@ class _Response(object):
         dbgdump(response_wrapper)
 
         return json.dumps(response_wrapper)
+    
+    def add_can_fulfill(self, can_fulfill: bool, score: float):
+        self._response['canFulfillIntent'] = {
+            "canFulfill": "YES" if can_fulfill else "NO",
+            "confidenceScore": str(score),
+        }
+        return self
 
     def add_directive(self, directive):
         self._response['directives'].append(directive)


### PR DESCRIPTION
# Description

We develop the chat extension. It used 'canFulFillIntent'  as a CEK spec.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
